### PR TITLE
Remove AppRater

### DIFF
--- a/app/src/main/java/org/fox/ttrss/FeedsActivity.java
+++ b/app/src/main/java/org/fox/ttrss/FeedsActivity.java
@@ -8,7 +8,6 @@ import org.fox.ttrss.types.Article;
 import org.fox.ttrss.types.ArticleList;
 import org.fox.ttrss.types.Feed;
 import org.fox.ttrss.types.FeedCategory;
-import org.fox.ttrss.util.AppRater;
 
 import android.animation.ObjectAnimator;
 import android.annotation.SuppressLint;
@@ -153,7 +152,6 @@ public class FeedsActivity extends OnlineActivity implements HeadlinesEventListe
 			ft.commit();
 				
 			if (!isAmazonDevice()) {
-				AppRater.appLaunched(this);
 				checkTrial(true);
 			}
 


### PR DESCRIPTION
Since this is a fork of the app, not the app, and it's not distributed through the Play Store, AppRater should be removed. This change should make it not occur (haven't tested it), and util\AppRater.java is probably safe to delete entirely after this change.

PS - Issues is not enabled on this repo. :)
